### PR TITLE
Trio-style .listen() helper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,9 @@ Everything should work the same way. Please
 Helpers
 -------
 
-In addiction to ``asyncpg``-compatible API, ``triopg`` provides Trio-style
-``.listen()`` helper for
-`Postgres LISTEN statement <https://www.postgresql.org/docs/current/sql-listen.html>`__.
+In addition to ``asyncpg``-compatible API, ``triopg`` provides Trio-style
+``.listen()`` helper for the eponymous
+`Postgres statement <https://www.postgresql.org/docs/current/sql-listen.html>`__:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,8 @@ Quick example:
 
     trio_asyncio.run(main)
 
-API
----
+API basics
+----------
 
 ``triopg`` is a thin Trio-compatible wrapper around ``asyncpg``. The API is the same,
 with one exception - ``triopg`` does not support manual resource management.
@@ -78,3 +78,16 @@ Otherwise you can follow ``asyncpg``
 `reference <https://magicstack.github.io/asyncpg/current/api/>`__.
 Everything should work the same way. Please
 `file an issue <https://github.com/python-trio/triopg/issues/new>`__ if it doesn't.
+
+Helpers
+-------
+
+In addiction to ``asyncpg``-compatible API, ``triopg`` provides Trio-style
+``.listen()`` helper for
+`Postgres LISTEN statement <https://www.postgresql.org/docs/current/sql-listen.html>`__.
+
+.. code-block:: python
+
+    async with conn.listen('some.channel') as notifications:
+        async for notification in notifications:
+            print('Notification received:', notification)

--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,7 @@ There are two possible ways to fix it:
 1. Do less work in `async for` block and consume notifications as soon as they arrive.
 2. Try to increase max buffer size (``1`` by default). E.g. ``conn.listen('channel', max_buffer_size=64)``.
    For a detailed discussion on buffering, see Trio manual,
-   `"Buffering in channels" <https://trio.readthedocs.io/en/stable/reference-core.html#buffering-in-channels
->`__
+   `"Buffering in channels" <https://trio.readthedocs.io/en/stable/reference-core.html#buffering-in-channels>`__
    section.
 
 If nothing helps, `file an issue <https://github.com/python-trio/triopg/issues/new>`__.

--- a/README.rst
+++ b/README.rst
@@ -91,3 +91,18 @@ In addition to ``asyncpg``-compatible API, ``triopg`` provides Trio-style
     async with conn.listen('some.channel') as notifications:
         async for notification in notifications:
             print('Notification received:', notification)
+
+The helper could raise ``trio.TooSlowError`` if notifications are not consumed fast enough.
+There are two possible ways to fix it:
+
+1. Do less work in `async for` block and consume notifications as soon as they arrive.
+2. Try to increase max buffer size (``1`` by default). E.g. ``conn.listen('channel', max_buffer_size=64)``.
+   For a detailed discussion on buffering, see Trio manual,
+   `"Buffering in channels" <https://trio.readthedocs.io/en/stable/reference-core.html#buffering-in-channels
+>`__
+   section.
+
+If nothing helps, `file an issue <https://github.com/python-trio/triopg/issues/new>`__.
+
+(Ideally we would want to politely ask Postgres to slow down. Unfortunately,
+`LISTEN backpressure is not supported <https://github.com/MagicStack/asyncpg/issues/463>`__.)

--- a/newsfragments/13.feature.rst
+++ b/newsfragments/13.feature.rst
@@ -1,0 +1,1 @@
+Add ``.listen`` helper for Trio-style handling of LISTEN notifications.

--- a/triopg/__init__.py
+++ b/triopg/__init__.py
@@ -1,11 +1,12 @@
 """Top-level package for triopg."""
 
 from ._version import __version__
-from ._triopg import connect, create_pool
+from ._triopg import connect, create_pool, NOTIFY_OVERFLOW
 from .exceptions import *  # NOQA
 
 __all__ = (
     '__version__',
     'connect',
     'create_pool',
+    'NOTIFY_OVERFLOW',
 ) + exceptions.__all__  # NOQA

--- a/triopg/_tests/test_triopg.py
+++ b/triopg/_tests/test_triopg.py
@@ -174,7 +174,7 @@ async def test_listener(triopg_conn, asyncpg_execute):
     await triopg_conn.remove_listener("foo", _listener)
     assert await asyncpg_execute("NOTIFY foo, '3'")  # Should be ignored
 
-    with trio.fail_after(1):
+    with trio.fail_after(5):
         channel, payload = await listener_receiver.receive()
     assert channel == "foo"
     assert payload == "2"

--- a/triopg/_tests/test_triopg.py
+++ b/triopg/_tests/test_triopg.py
@@ -192,6 +192,8 @@ async def test_listen(nursery, triopg_conn, asyncpg_execute):
             task_status.started()
             async for change in changes:
                 received.append(change)
+                if change == '2':
+                    break
 
     await nursery.start(listen)
 

--- a/triopg/_tests/test_triopg.py
+++ b/triopg/_tests/test_triopg.py
@@ -181,9 +181,11 @@ async def test_listener(triopg_conn, asyncpg_execute):
     with pytest.raises(trio.WouldBlock):
         await listener_receiver.receive_nowait()
 
+
 @pytest.mark.trio
 async def test_listener_cancel(triopg_conn, asyncpg_execute):
-    def _listener(*args): pass
+    def _listener(*args):
+        pass
 
     assert not triopg_conn._asyncpg_conn._listeners
     await triopg_conn.add_listener("foo", _listener)
@@ -197,6 +199,7 @@ async def test_listener_cancel(triopg_conn, asyncpg_execute):
 
     # clean up to prevent "active connection left" warning
     await triopg_conn.remove_listener("foo", _listener)
+
 
 @pytest.mark.trio
 async def test_listen(triopg_conn, asyncpg_execute):

--- a/triopg/_tests/test_triopg.py
+++ b/triopg/_tests/test_triopg.py
@@ -1,4 +1,3 @@
-import sys
 import pytest
 import trio
 import trio_asyncio
@@ -183,7 +182,6 @@ async def test_listener(triopg_conn, asyncpg_execute):
         await listener_receiver.receive_nowait()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason='missing contextlib.asynccontextmanager')
 @pytest.mark.trio
 async def test_listen(nursery, triopg_conn, asyncpg_execute):
 
@@ -203,3 +201,5 @@ async def test_listen(nursery, triopg_conn, asyncpg_execute):
     await asyncpg_execute("NOTIFY foo, '2'")
 
     assert received == ["1", "2"]
+
+    await trio.testing.wait_all_tasks_blocked()

--- a/triopg/_tests/test_triopg.py
+++ b/triopg/_tests/test_triopg.py
@@ -185,7 +185,7 @@ async def test_listener(triopg_conn, asyncpg_execute):
 @pytest.mark.trio
 async def test_listener_cancel(triopg_conn, asyncpg_execute):
     def _listener(*args):
-        pass
+        pass  # pragma: no cover
 
     assert not triopg_conn._asyncpg_conn._listeners
     await triopg_conn.add_listener("foo", _listener)
@@ -260,4 +260,4 @@ async def test_listen_cancel(triopg_conn):
         async with triopg_conn.listen("foo", max_buffer_size=1):
             assert triopg_conn._asyncpg_conn._listeners
             cancel_scope.cancel()
-        assert not triopg_conn._asyncpg_conn._listeners
+    assert not triopg_conn._asyncpg_conn._listeners

--- a/triopg/_tests/test_triopg.py
+++ b/triopg/_tests/test_triopg.py
@@ -185,7 +185,9 @@ async def test_listener(triopg_conn, asyncpg_execute):
 async def assert_listeners(conn, status):
     """Assert expected listeners `status`, on Postgres and on asyncpg"""
 
-    pg = await conn.fetchval("select * from pg_listening_channels()") is not None
+    pg = await conn.fetchval(
+        "select * from pg_listening_channels()"
+    ) is not None
     assert pg == status
     assert bool(conn._asyncpg_conn._listeners) == status
 

--- a/triopg/_tests/test_triopg.py
+++ b/triopg/_tests/test_triopg.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 import trio
 import trio_asyncio
@@ -182,6 +183,7 @@ async def test_listener(triopg_conn, asyncpg_execute):
         await listener_receiver.receive_nowait()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='missing contextlib.asynccontextmanager')
 @pytest.mark.trio
 async def test_listen(nursery, triopg_conn, asyncpg_execute):
 

--- a/triopg/_triopg.py
+++ b/triopg/_triopg.py
@@ -135,12 +135,14 @@ class TrioConnectionProxy:
                 print('Postgres notification received:', notification)
         """
 
-        send_channel, receive_channel = trio.open_memory_channel(max_buffer_size)
+        send_channel, receive_channel = trio.open_memory_channel(
+            max_buffer_size
+        )
 
         # Memory channel is potentially bounded, calling `.send_nowait` could raise
         # trio.WouldBlock. We can't let WouldBlock propogate from _listen_callback.
         # The exception would vanish inside asyncpg.
-        # 
+        #
         # Instead we wrap this async context manager with a cancel scope, cancel() it
         # on WouldBlock exception, and turn the cancellation into TooSlowError.
         cancel_scope = trio.CancelScope()
@@ -158,7 +160,7 @@ class TrioConnectionProxy:
             with cancel_scope:
                 yield receive_channel
                 # Give a chance for cancellation to propagate sooner
-                await trio.sleep(0)  
+                await trio.sleep(0)
             await self.remove_listener(channel, _listen_callback)
 
             # Convert cancellation to an error

--- a/triopg/_triopg.py
+++ b/triopg/_triopg.py
@@ -3,14 +3,7 @@ from inspect import iscoroutinefunction
 import trio
 import asyncpg
 import trio_asyncio
-
-try:
-    from contextlib import asynccontextmanager
-except ImportError:
-    def asynccontextmanager(f):
-        def error(*args):
-            raise NotImplementedError('Python 3.7+ only')
-        return error
+from async_generator import asynccontextmanager
 
 
 def _shielded(f):

--- a/triopg/_triopg.py
+++ b/triopg/_triopg.py
@@ -1,5 +1,6 @@
 from functools import wraps, partial
 from inspect import iscoroutinefunction
+from contextlib import asynccontextmanager
 import trio
 import asyncpg
 import trio_asyncio
@@ -224,3 +225,25 @@ class TrioPoolProxy:
 
     async def __aexit__(self, *exc):
         return await self.close()
+
+
+@asynccontextmanager
+async def listen(conn, channel):
+    """LISTEN on `channel` notifications and return memory channel to iterate over
+
+    For example:
+
+    async with listen(conn, 'some.changes') as changes:
+        async for change in changes:
+            print('Postgres notification received:', change)
+    """
+
+    send_channel, receive_channel = trio.open_memory_channel(1)
+
+    def _listen_callback(c, pid, chan, payload):
+        send_channel.send_nowait(payload)
+
+    await conn.add_listener(channel, _listen_callback)
+    async with send_channel:
+        yield receive_channel
+    await conn.remove_listener(channel, _listen_callback)


### PR DESCRIPTION
This is an attempt to implement a friendly Trio-style `conn.listen()` helper. It's surprisingly complex due to the fact that `asyncpg` does not seem to support applying backpressure when we can't keep up with notifications. Without backpressure we only have two options:

1. Unbounded buffer, which Trio manual warns against.
2. Limited buffer, with a way to signal that we are not keeping up.

This PR implements both options: `.listen(..., max_buffer_size=inf)` vs `.listen(..., max_buffer_size=1)`. However, handling "not-keeping-up" error proved to be complicated, because `asyncpg` uses callback for its `LISTEN` implementation.

**Update:** I've simplified the solution using `NOTIFY_OVERFLOW` marker, [suggested](https://github.com/python-trio/triopg/pull/13#issuecomment-757779342) by @njsmith .