### PR TITLE
correctly proxy PreparedStatement non-async methods

### DIFF
--- a/newsfragments/14.bugfix.rst
+++ b/newsfragments/14.bugfix.rst
@@ -1,0 +1,2 @@
+Correctly proxy ordinary (non-async) ``PreparedStatement`` methods.
+For example, ``.get_statusmsg()``, ``.get_query()`` etc.

--- a/triopg/_tests/test_triopg.py
+++ b/triopg/_tests/test_triopg.py
@@ -112,6 +112,14 @@ async def test_prepared_statement(triopg_conn):
 
 
 @pytest.mark.trio
+async def test_prepared_statement_statusmsg(triopg_conn):
+    stmt = await triopg_conn.prepare("VALUES (1), (1), (1)")
+    await stmt.fetch()
+    assert stmt.get_statusmsg() == 'SELECT 3'
+    assert stmt.get_query() == 'VALUES (1), (1), (1)'
+
+
+@pytest.mark.trio
 async def test_execute_many(triopg_conn, asyncpg_execute):
     await triopg_conn.execute(
         """

--- a/triopg/_triopg.py
+++ b/triopg/_triopg.py
@@ -90,6 +90,8 @@ class TrioStatementProxy:
     def __getattr__(self, attr):
         target = getattr(self._asyncpg_statement, attr)
 
+        # iscoroutinefunction(target) is not enough, because PreparedStatement
+        # methods are wrapped with @connresource.guarded
         if iscoroutinefunction(target.__wrapped__
                                if hasattr(target, '__wrapped__') else target):
 

--- a/triopg/_triopg.py
+++ b/triopg/_triopg.py
@@ -90,7 +90,8 @@ class TrioStatementProxy:
     def __getattr__(self, attr):
         target = getattr(self._asyncpg_statement, attr)
 
-        if callable(target):
+        if iscoroutinefunction(target.__wrapped__
+                               if hasattr(target, '__wrapped__') else target):
 
             @wraps(target)
             @trio_asyncio.aio_as_trio


### PR DESCRIPTION
This PR lets you use prepared statement methods like `.get_statusmsg()` and `.get_query()`:

```python
stmt = await conn("select version()")
await stmt.fetch()
stmt.get_statusmsg() # => 'SELECT 1'
stmt.get_query() # => 'select version()'
```