### PR TITLE
add warning in README, and classifier development status: inactive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@
 triopg
 ======
 
+WARNING: this project is not actively maintained
+================================================
+
 Welcome to `triopg <https://github.com/python-trio/triopg>`__!
 
 PostgreSQL client for `Trio <https://trio.readthedocs.io/>`__ based on

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     keywords=["async", "trio", "sql", "postgresql", "asyncpg"],
     python_requires=">=3.6",
     classifiers=[
+        "Development Status :: 7 - Inactive",
         "License :: OSI Approved :: MIT License",
         "License :: OSI Approved :: Apache Software License",
         "Framework :: Trio",


### PR DESCRIPTION
This project is currently very dead, so probably good to indicate that.
Do we need to make a new "release" to get the classifier on pypi updated?


It might also be nice to recommend alternatives.